### PR TITLE
Assure Learning Rate Scheduler does not increase the learning rate

### DIFF
--- a/src/gluonts/trainer/learning_rate_scheduler.py
+++ b/src/gluonts/trainer/learning_rate_scheduler.py
@@ -60,6 +60,11 @@ class MetricAttentiveScheduler(mx.lr_scheduler.LRScheduler):
     ) -> None:
 
         assert base_lr > 0, f"base_lr should be positive, got {base_lr}"
+        
+        assert (
+            base_lr > min_lr, 
+            f"base_lr should greater than min_lr, {base_lr} <= {min_lr}"
+        )
 
         assert (
             0 < decay_factor < 1


### PR DESCRIPTION
*Issue #, if available:*
When the base learning rate is smaller than the minimum learning rate, the following operation is applied: 

> max(min_lr, factor*base_lr)

This effectively increases the learning rate once the patience epochs without improvement are reached. 

*Description of changes:*

I included an assert statement to break in case min_lr > base_lr